### PR TITLE
Add E2E testing set up steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ git clone git@github.com:descope-sample-apps/b2c-retail-sample-app.git
 ```
 REACT_APP_DESCOPE_PROJECT_ID="YOUR PROJECT ID" // Required for Descope authentication
 REACT_APP_DESCOPE_SIGN_IN_FLOW_ID="sign-up-or-in" // Optional, if you would like to use a flow other than sign-up-or-in
+REACT_APP_DESCOPE_MANAGEMENT_KEY="YOUR MANAGEMENT KEY" // Optional, if you would like to run E2E tests
 DESCOPE_BASE_URL="http://localhost:8000" // Optional, if you would like to use a different base URL
 ```
 _You can get your project-id [here](https://app.descope.com/settings/project)_.
@@ -37,6 +38,13 @@ yarn start
 
 #### 5. Open the app
 Browse to `https://localhost:3000`
+
+
+## Testing
+To run Cypress E2E tests:
+```
+yarn run cypress open
+```
 
 ## Learn More
 To learn more please see the [Descope Documentation and API reference page](https://docs.descope.com/).


### PR DESCRIPTION
Followup on PR #55 to add E2E testing set up steps (adding descope management key and command line instruction for running test) to readme.