### PR TITLE
Show TenantAdmin Toggle if not using project ID from `.env`

### DIFF
--- a/src/components/header/NavBar.js
+++ b/src/components/header/NavBar.js
@@ -63,6 +63,9 @@ const NavBar = ({ handleClick, brandText }) => {
       return "Profile";
     }
   };
+  const showAdminSwitch = () => {
+    return localStorage.getItem("projectId") === null;
+  }
   if (isUserLoading) {
     return <></>
   }
@@ -71,10 +74,10 @@ const NavBar = ({ handleClick, brandText }) => {
     <div>
       <Typography.Title level={5}>Hey, {getDisplayName(user)}</Typography.Title>
       <Divider />
-      <AdminSwitch
+      {showAdminSwitch() && <AdminSwitch
         isTenantAdmin={isTenantAdmin()}
         loginId={user.loginIds[0]}
-      />
+      />}
       <Divider />
       <p style={{ color: "red", cursor: "pointer" }} onClick={logoutUser}>
         Log out


### PR DESCRIPTION
Since our management key must match the project ID for the Tenant Admin toggle, we'll need to disable this feature anytime a different project ID is set.

It seems that the project ID can be set by users via simply including it in the URL, which then stores the project ID in local storage.

So, we just add a boolean check for if local storage `projectId` is null to show the toggle.