### PR TITLE
Fix staticBaseUrl for sandbox.dolrr.biz

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,11 +25,14 @@ const AppRoot = () => {
   }
 
   const authProviderProps = useAuthProviderProps();
-
+  const descopeProjectId = projectId || process.env.REACT_APP_DESCOPE_PROJECT_ID
+  const descopeBaseUrl = baseUrl || process.env.REACT_APP_DESCOPE_BASE_URL
+  const descopeStaticBaseUrl = `${descopeBaseUrl}/pages`
   return (
     <AuthProvider
-      projectId={projectId || process.env.REACT_APP_DESCOPE_PROJECT_ID}
-      baseUrl = {baseUrl || process.env.REACT_APP_DESCOPE_BASE_URL}
+      projectId={descopeProjectId}
+      baseUrl = {descopeBaseUrl}
+      baseStaticUrl={descopeStaticBaseUrl}
       {...authProviderProps}
     >
       <App />


### PR DESCRIPTION
This pull request refactors the initialization of Descope configuration variables in the `AppRoot` component to improve readability and maintainability.

* Refactored Descope configuration:
  * Introduced local variables `descopeProjectId`, `descopeBaseUrl`, and `descopeStaticBaseUrl` to store derived values for Descope configuration, replacing inline expressions. (`[src/App.jsL28-R35](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L28-R35)`)
  * Added a new `baseStaticUrl` prop to the `AuthProvider` component, using the newly defined `descopeStaticBaseUrl` variable. (`[src/App.jsL28-R35](diffhunk://#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L28-R35)`)