### PR TITLE
update descope react SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@ant-design/icons": "5.0.1",
         "@chakra-ui/react": "^2.8.2",
-        "@descope/node-sdk": "1.7.21",
-        "@descope/react-sdk": "^2.25.2",
+        "@descope/node-sdk": "1.9.0",
+        "@descope/react-sdk": "2.27.12",
         "@emotion/react": "11.11.3",
         "@emotion/styled": "11.11.0",
         "@testing-library/jest-dom": "5.17.0",
@@ -2629,15 +2629,15 @@
       }
     },
     "node_modules/@descope/access-key-management-widget": {
-      "version": "0.5.29",
-      "resolved": "https://registry.npmjs.org/@descope/access-key-management-widget/-/access-key-management-widget-0.5.29.tgz",
-      "integrity": "sha512-jjXQ7EJMNJQzZvM3+f34kS18SD/XgeLP3IEWGRyeAs8JlzvobxS5Jjqsu6a90DY1hb4iVuXBBxdmw8P5/Vxyeg==",
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/@descope/access-key-management-widget/-/access-key-management-widget-0.5.45.tgz",
+      "integrity": "sha512-rm8RqmZr7iB2iIz1tLp9H92SOaSsWPMoWHhb7eEtet/qNSXlIIOXYCUkTrw/bGgneNfzPsKMIu7oE+q6JZyRxQ==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2647,15 +2647,15 @@
       }
     },
     "node_modules/@descope/applications-portal-widget": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@descope/applications-portal-widget/-/applications-portal-widget-0.5.12.tgz",
-      "integrity": "sha512-mL0A1dUCG1as1gF4kLKKnxLijLp9r+YQoc4FfhYo09+N6qqse8VjJnGrLE+fNS1isgzK/dkc7i9DGdMpANArZQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@descope/applications-portal-widget/-/applications-portal-widget-0.6.5.tgz",
+      "integrity": "sha512-kV2he1ByuYFtCvG3HbbqgwM2YS1pN8roVagwY+8Vu7zN8tc0Ec4xBmckEcarAectIYFjIns5uS7aZewSZMHnTA==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2665,15 +2665,15 @@
       }
     },
     "node_modules/@descope/audit-management-widget": {
-      "version": "0.5.29",
-      "resolved": "https://registry.npmjs.org/@descope/audit-management-widget/-/audit-management-widget-0.5.29.tgz",
-      "integrity": "sha512-sU4KMcxU2Yq50t7mQ8YbGBM1jPMBEo+xHm7fc0amYpPYS08J0wOe7nwE+lAiUcj0X9v8rmievz3AgZ9rwY/U8g==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@descope/audit-management-widget/-/audit-management-widget-0.6.7.tgz",
+      "integrity": "sha512-YHep1D2CnG2n8skfDNQHlrZ9+RY9pta4KHwVhDzCuf6PCvQZfsddmKK9MFc5f3Je4+lcbInccIgrpMYqVii5Hg==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2683,9 +2683,9 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.53.1.tgz",
-      "integrity": "sha512-KbrtD5VU4Jcis/kKcATTZJ1XxyKTurm8LLlnpJP5GrSRIN5WOYk7tGtXGA1hokWYDyRZCvgheTWm4KxEdCYNeQ==",
+      "version": "2.56.1",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.56.1.tgz",
+      "integrity": "sha512-YiMO7Mi8pZw1s9oxVyKPSifsyhGlnhf+iWzKEuH8xiZcqAR1ZwDTTqXP5X8s9Wm/Xly7/s0l7RqoDEsQu/GDKw==",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "4.0.0"
@@ -2698,31 +2698,31 @@
       "license": "MIT"
     },
     "node_modules/@descope/node-sdk": {
-      "version": "1.7.21",
-      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.7.21.tgz",
-      "integrity": "sha512-0QFnO5rUUXnKI5AY6JpQ0BiWjnLhsN9iC1BAURKMecDQJPL38OQM1Svl4+5bcAcWX4DVbybWcVYOcohMkTPmZA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.9.0.tgz",
+      "integrity": "sha512-R7pWT+C0hHh69BAXrBA/ZfgH7aLmGlcuiXAN70Ond4COHihGRLr8DKMJ3G+WRWsptsVdxA/qQ9qDVSwaaxqdfw==",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.53.1",
+        "@descope/core-js-sdk": "2.56.1",
         "cross-fetch": "^4.0.0",
         "jose": "5.2.2",
         "tslib": "^2.0.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/@descope/outbound-applications-widget": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@descope/outbound-applications-widget/-/outbound-applications-widget-0.2.12.tgz",
-      "integrity": "sha512-/XaeX/5GYyBHQw/K2fskQMpRKVR4E9gomr4Q6F7QKgTUb6C2IVK+/9FUjwSLnoIb2hxrjOs3yGidaXZybh2BHA==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@descope/outbound-applications-widget/-/outbound-applications-widget-0.2.37.tgz",
+      "integrity": "sha512-xEM5VUnYjvJ/sI0uOJMOkYZGMWEuInpVJQFcMExkYSklnGDrWVTZY61VWz9TW643BpTIBxOE9/zBnpztP0LeUw==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-component": "3.53.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-component": "3.62.0",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2732,23 +2732,23 @@
       }
     },
     "node_modules/@descope/react-sdk": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-2.25.2.tgz",
-      "integrity": "sha512-iRC0znsxFXpd1ox3KpNtNEVQIgbyDfdsuUWAatLP8p4k+VxB9QyjoVU4f5yGksbPeWaDLAHmmFomN5C12QmfLg==",
+      "version": "2.27.12",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-2.27.12.tgz",
+      "integrity": "sha512-dolq5hg2Qb8YA5e4Kmhcaw075+AjR++5uY70PgR6rzEhW33VdODyajO8yP433vtmWNHDuJCYefUVcUIkVAZKVg==",
       "license": "MIT",
       "dependencies": {
-        "@descope/access-key-management-widget": "0.5.29",
-        "@descope/applications-portal-widget": "0.5.12",
-        "@descope/audit-management-widget": "0.5.29",
-        "@descope/core-js-sdk": "2.54.0",
-        "@descope/outbound-applications-widget": "0.2.12",
-        "@descope/role-management-widget": "0.5.21",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/tenant-profile-widget": "0.5.12",
-        "@descope/user-management-widget": "0.10.12",
-        "@descope/user-profile-widget": "0.8.12",
-        "@descope/web-component": "3.53.0",
-        "@descope/web-js-sdk": "1.42.0"
+        "@descope/access-key-management-widget": "0.5.45",
+        "@descope/applications-portal-widget": "0.6.5",
+        "@descope/audit-management-widget": "0.6.7",
+        "@descope/core-js-sdk": "2.61.0",
+        "@descope/outbound-applications-widget": "0.2.37",
+        "@descope/role-management-widget": "0.5.37",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/tenant-profile-widget": "0.5.36",
+        "@descope/user-management-widget": "0.11.25",
+        "@descope/user-profile-widget": "0.10.0",
+        "@descope/web-component": "3.62.0",
+        "@descope/web-js-sdk": "1.48.4"
       },
       "peerDependencies": {
         "@types/react": ">=16",
@@ -2756,24 +2756,24 @@
       }
     },
     "node_modules/@descope/react-sdk/node_modules/@descope/core-js-sdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.54.0.tgz",
-      "integrity": "sha512-9JMtoWNXdHCAUOLw0jdxsD+U5Lg13z+xgaM1h5hjxMrlGWX1/D9WM7OcAP6Sxt2L5zUotgIgT9fPhtQyyuGxwA==",
+      "version": "2.61.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.61.0.tgz",
+      "integrity": "sha512-lC0OVkQ3tRbAlNRdic470M37uk80kqOJSDW5tF35HUxz1Enn2vIfNuVPC5Mb+L1nDf3WCbTakdjbagBUrrgXkA==",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "4.0.0"
       }
     },
     "node_modules/@descope/role-management-widget": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@descope/role-management-widget/-/role-management-widget-0.5.21.tgz",
-      "integrity": "sha512-vHYAv3JUiDyVJXDMEzlIhCtI5tbfsmnfb1ozxyS0oflpwsMKvMHz+yuO4k+R6o29usAbtQu1/ZUosWQitPUC+w==",
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@descope/role-management-widget/-/role-management-widget-0.5.37.tgz",
+      "integrity": "sha512-izyNqmpi913vOB/QQkd0izcX9gyPB6vqwCcmhH08D7//axuAOraS9rLEfllCKoW5/kyTTCkmuBg3vwy5uhg3hg==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2783,32 +2783,32 @@
       }
     },
     "node_modules/@descope/sdk-component-drivers": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@descope/sdk-component-drivers/-/sdk-component-drivers-0.8.1.tgz",
-      "integrity": "sha512-7VBxIWMQuiY9J9xYeuCGNaLjnNG01+t+Sc6D+mg9G1TLsVb+2Kkkj1z+qJ3hsSHOBZWjWiclmku4p+I3GHA5Bw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-component-drivers/-/sdk-component-drivers-0.10.0.tgz",
+      "integrity": "sha512-a6LB/JMKsNhXbQv5F8ndZts8pDbDGhNNMx+AqqF16e2B87dqpH5UZG/VBBKfXYXD2UKhbXjQKrg9hmppnO7D9g==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-helpers": "0.5.1",
+        "@descope/sdk-helpers": "0.7.0",
         "tslib": "2.8.1"
       }
     },
     "node_modules/@descope/sdk-helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@descope/sdk-helpers/-/sdk-helpers-0.5.1.tgz",
-      "integrity": "sha512-U+ACByV1TFq84WfkXk0Nvu+4IVJ8j3I6u6aS1MA4fYlN+VNQqZ51igiNsKdL+zJpj1T1jH6e7TOZvy0r+gCv0g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-helpers/-/sdk-helpers-0.7.0.tgz",
+      "integrity": "sha512-y+mwjwiSy3yL2ogMz3g2c+KdF4SRU3APZNXAdb+aikgaw5VZIWeUIPWft8xIZPejljc5iCS6wtjUpOeyCn1jUQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       }
     },
     "node_modules/@descope/sdk-mixins": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.15.0.tgz",
-      "integrity": "sha512-9eppRaMi6ZquSRqsYwQvPEdnWEkFesylurldmDJoTGW7SlmdOv5wrU7HkwB+C4hjX6DB/1b69bO1X9x/yspjmQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.2.tgz",
+      "integrity": "sha512-ChqfSFrK+2A5SIA17k4GizCnmtJtKCBouA2niwg++n0aV9998N5WLajFVMuKRcTKqUlEop9GnxWrhXx22VN76g==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
         "tslib": "2.8.1"
       },
       "peerDependencies": {
@@ -2819,16 +2819,16 @@
       }
     },
     "node_modules/@descope/tenant-profile-widget": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@descope/tenant-profile-widget/-/tenant-profile-widget-0.5.12.tgz",
-      "integrity": "sha512-9kOVbwchua2p4KqU3EExRbg3kynmRJFar+4kOyIHCObb6wQY4Wp41JkjRGEH//I6cPbf6swqVJEo2uxZK8mguQ==",
+      "version": "0.5.36",
+      "resolved": "https://registry.npmjs.org/@descope/tenant-profile-widget/-/tenant-profile-widget-0.5.36.tgz",
+      "integrity": "sha512-HNV5qu2JMrHJux2G4sg3GUfuDxV0mshB3OrOeC/q4bVDYz6pSeHf7wqenlodveBuntGonpqwerjsbK/aRrZPYA==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-component": "3.53.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-component": "3.62.0",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2837,13 +2837,13 @@
         "tslib": "2.8.1"
       },
       "optionalDependencies": {
-        "@descope/core-js-sdk": "2.54.0"
+        "@descope/core-js-sdk": "2.61.0"
       }
     },
     "node_modules/@descope/tenant-profile-widget/node_modules/@descope/core-js-sdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.54.0.tgz",
-      "integrity": "sha512-9JMtoWNXdHCAUOLw0jdxsD+U5Lg13z+xgaM1h5hjxMrlGWX1/D9WM7OcAP6Sxt2L5zUotgIgT9fPhtQyyuGxwA==",
+      "version": "2.61.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.61.0.tgz",
+      "integrity": "sha512-lC0OVkQ3tRbAlNRdic470M37uk80kqOJSDW5tF35HUxz1Enn2vIfNuVPC5Mb+L1nDf3WCbTakdjbagBUrrgXkA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2851,16 +2851,16 @@
       }
     },
     "node_modules/@descope/user-management-widget": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/@descope/user-management-widget/-/user-management-widget-0.10.12.tgz",
-      "integrity": "sha512-MkE6aKv3DyWxePnobooiIYVOvbn9dqE7p1cgtdfx8QK/rEFDnl/Yo5YpiuQx3PakhfBcBKXqCehYxwU0VgNwvw==",
+      "version": "0.11.25",
+      "resolved": "https://registry.npmjs.org/@descope/user-management-widget/-/user-management-widget-0.11.25.tgz",
+      "integrity": "sha512-CDGL0Qj03msKE2bV1c4iI4sCmFd1QxRmgzAb/+r0Jb9Z5eOUn1gBVJagdOuKOOVDmlB5IzAJufJ+eemb3OGakw==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-component": "3.53.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-component": "3.62.0",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "libphonenumber-js": "1.11.17",
@@ -2871,16 +2871,16 @@
       }
     },
     "node_modules/@descope/user-profile-widget": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@descope/user-profile-widget/-/user-profile-widget-0.8.12.tgz",
-      "integrity": "sha512-GPz102HVsVTpy6b+0fGPc0fi4z76/w17iSKViOOuDps9kTma2M5TZumluhPuyuLnBtvte1lixSEFkFLYkhgDuA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@descope/user-profile-widget/-/user-profile-widget-0.10.0.tgz",
+      "integrity": "sha512-JorPe59DriSqAgxQqJFca38k3ujXiyB1p7xOt5LlgS5ClmHfoqmLWAb+D2tdorBKarvlXCltdCNTKnBhaaXoFA==",
       "license": "MIT",
       "dependencies": {
-        "@descope/sdk-component-drivers": "0.8.1",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-component": "3.53.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-component-drivers": "0.10.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-component": "3.62.0",
+        "@descope/web-js-sdk": "1.48.4",
         "@reduxjs/toolkit": "^2.0.1",
         "immer": "^10.0.3",
         "redux": "5.0.1",
@@ -2889,13 +2889,13 @@
         "tslib": "2.8.1"
       },
       "optionalDependencies": {
-        "@descope/core-js-sdk": "2.54.0"
+        "@descope/core-js-sdk": "2.61.0"
       }
     },
     "node_modules/@descope/user-profile-widget/node_modules/@descope/core-js-sdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.54.0.tgz",
-      "integrity": "sha512-9JMtoWNXdHCAUOLw0jdxsD+U5Lg13z+xgaM1h5hjxMrlGWX1/D9WM7OcAP6Sxt2L5zUotgIgT9fPhtQyyuGxwA==",
+      "version": "2.61.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.61.0.tgz",
+      "integrity": "sha512-lC0OVkQ3tRbAlNRdic470M37uk80kqOJSDW5tF35HUxz1Enn2vIfNuVPC5Mb+L1nDf3WCbTakdjbagBUrrgXkA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2903,26 +2903,26 @@
       }
     },
     "node_modules/@descope/web-component": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.53.0.tgz",
-      "integrity": "sha512-S9WNzPQ5lbwxRQf0za0KzGEFUShRExnPerwDLGy14Ls+g3sFWJakrj7K+yvflttPI1detLMcyQn7LfOgsniI4w==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.62.0.tgz",
+      "integrity": "sha512-o5ErpOZRLN+ut7yLJAJYKajEOflpXpj8MTdcUM2z7KRd7d5XR3/Cf96205/LYUelaRkp0xFd+FPD2gqp+CgsYA==",
       "license": "MIT",
       "dependencies": {
         "@descope/escape-markdown": "0.1.6",
-        "@descope/sdk-helpers": "0.5.1",
-        "@descope/sdk-mixins": "0.15.0",
-        "@descope/web-js-sdk": "1.42.0",
+        "@descope/sdk-helpers": "0.7.0",
+        "@descope/sdk-mixins": "0.16.2",
+        "@descope/web-js-sdk": "1.48.4",
         "@fingerprintjs/fingerprintjs-pro": "3.11.6",
         "tslib": "2.8.1"
       }
     },
     "node_modules/@descope/web-js-sdk": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.42.0.tgz",
-      "integrity": "sha512-ESRA+KP2pf7Z9K/KKc4WJk4bvCCuz9zfmBW6gB/xFhuQpQw35fy3IFgryodIPG2iR3elXssb1oYI/+uaSqFqNw==",
+      "version": "1.48.4",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.48.4.tgz",
+      "integrity": "sha512-IhU5c0a9UVitajE1etvXDMD9xrG0sUAYyx7E1HOEUW4uOJB/HYBWQye3grRei/IV1CSdUpSJXG1kHSQpzYZRcg==",
       "license": "MIT",
       "dependencies": {
-        "@descope/core-js-sdk": "2.54.0",
+        "@descope/core-js-sdk": "2.61.0",
         "@fingerprintjs/fingerprintjs-pro": "3.11.6",
         "js-cookie": "3.0.5",
         "jwt-decode": "4.0.0",
@@ -2930,9 +2930,9 @@
       }
     },
     "node_modules/@descope/web-js-sdk/node_modules/@descope/core-js-sdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.54.0.tgz",
-      "integrity": "sha512-9JMtoWNXdHCAUOLw0jdxsD+U5Lg13z+xgaM1h5hjxMrlGWX1/D9WM7OcAP6Sxt2L5zUotgIgT9fPhtQyyuGxwA==",
+      "version": "2.61.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.61.0.tgz",
+      "integrity": "sha512-lC0OVkQ3tRbAlNRdic470M37uk80kqOJSDW5tF35HUxz1Enn2vIfNuVPC5Mb+L1nDf3WCbTakdjbagBUrrgXkA==",
       "license": "MIT",
       "dependencies": {
         "jwt-decode": "4.0.0"
@@ -3988,9 +3988,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4014,9 +4014,9 @@
       }
     },
     "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.0.tgz",
-      "integrity": "sha512-dlzb07f5LDY+tzs+iLCSXV2yuhaYfezqyZQc+n6baLECWkOMEWxkECAOnXL0ba7lsA25fM9b2jtzpu/uxo1a7g==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -20035,20 +20035,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@ant-design/icons": "5.0.1",
     "@chakra-ui/react": "^2.8.2",
     "@descope/node-sdk": "1.9.0",
-    "@descope/react-sdk": "^2.25.7",
+    "@descope/react-sdk": "2.27.12",
     "@emotion/react": "11.11.3",
     "@emotion/styled": "11.11.0",
     "@testing-library/jest-dom": "5.17.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `@descope/react-sdk` to 2.27.12 and pin the version to ensure reproducible builds. This also refreshes Descope widgets and SDKs to the latest compatible releases.

- **Dependencies**
  - Pin `@descope/react-sdk` to 2.27.12 (was ^2.25.x).
  - Transitive updates include `@descope/web-js-sdk` 1.48.4, `@descope/web-component` 3.62.0, and `@descope/core-js-sdk` 2.61.0 (React/web) and 2.56.1 (Node).
  - All Descope widgets updated to latest compatible versions (access-key, applications-portal, audit-management, outbound-applications, tenant-profile, user-management, user-profile, role-management).
  - Minor lockfile refresh: `@reduxjs/toolkit` 2.12.0 and `immer` 11.1.8.

- **Migration**
  - Ensure Node 16+ in runtime (required by `@descope/node-sdk` 1.9.0).

<sup>Written for commit ca6557bd22b1a62a16d3969158a246430642f395. Summary will update on new commits. <a href="https://cubic.dev/pr/descope-sample-apps/b2b-react-sample-app/pull/332?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

